### PR TITLE
.git extension is not required by Gitlab, Bitbucket, or Github

### DIFF
--- a/giturlparse/platforms/bitbucket.py
+++ b/giturlparse/platforms/bitbucket.py
@@ -3,8 +3,8 @@ from .base import BasePlatform
 
 class BitbucketPlatform(BasePlatform):
     PATTERNS = {
-        'https': r'https://(?P<_user>.+)@(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+).git',
-        'ssh': r'git@(?P<domain>.+):(?P<owner>.+)/(?P<repo>.+).git'
+        'https': r'https://(?P<_user>.+)@(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+)(?:\.git)?',
+        'ssh': r'git@(?P<domain>.+):(?P<owner>.+)/(?P<repo>.+)(?:\.git)?'
     }
     FORMATS = {
         'https': r'https://%(owner)s@%(domain)s/%(owner)s/%(repo)s.git',

--- a/giturlparse/platforms/github.py
+++ b/giturlparse/platforms/github.py
@@ -4,9 +4,9 @@ from .base import BasePlatform
 
 class GitHubPlatform(BasePlatform):
     PATTERNS = {
-        'https': r'https://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+).git',
-        'ssh': r'git@(?P<domain>.+):(?P<owner>.+)/(?P<repo>.+).git',
-        'git': r'git://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+).git',
+        'https': r'https://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+)(?:\.git)?',
+        'ssh': r'git@(?P<domain>.+):(?P<owner>.+)/(?P<repo>.+)(?:\.git)?',
+        'git': r'git://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+)(?:\.git)?',
     }
     FORMATS = {
         'https': r'https://%(domain)s/%(owner)s/%(repo)s.git',

--- a/giturlparse/platforms/gitlab.py
+++ b/giturlparse/platforms/gitlab.py
@@ -4,9 +4,9 @@ from .base import BasePlatform
 
 class GitLabPlatform(BasePlatform):
     PATTERNS = {
-        'https': r'https://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+).git',
-        'ssh': r'git@(?P<domain>.+):(?P<owner>.+)/(?P<repo>.+).git',
-        'git': r'git://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+).git',
+        'https': r'https://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+)(?:\.git)?',
+        'ssh': r'git@(?P<domain>.+):(?P<owner>.+)/(?P<repo>.+)(?:\.git)?',
+        'git': r'git://(?P<domain>.+)/(?P<owner>.+)/(?P<repo>.+)(?\.git)?',
     }
     FORMATS = {
         'https': r'https://%(domain)s/%(owner)s/%(repo)s.git',


### PR DESCRIPTION
… and also, the `.` in `.git` is a literal and needs to be escaped.